### PR TITLE
feat: independent prediction-arbitrage health check service (#29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ operator-facing: what changed, which workflow is affected, and what was verified
 
 ## 2026-08-07
 
+- #29 新增独立 prediction-arbitrage 健康检查后端服务（launchd label
+  `com.open-trader.prediction-arbitrage-health`，RunAtLoad/KeepAlive，只装生产环境，
+  与其他 worktree 部署无关）：每 2 小时检查 8766 状态端点与 healthz、heartbeat≤60s、
+  universe≤300s、breaker、cross-venue、relation catalog、universe_retry_exhausted、
+  readiness（执行被挡即 FAIL）、LLM 近 2 小时成功率、dashboard PID/运行 SHA；结果
+  PASS/WARN/FAIL 每次发飞书（PASS 一行摘要，WARN/FAIL 逐项带值带原因）；飞书未配置
+  显示 WARN，发送失败记日志下轮重试；`prediction-arb health-check --once` 可手动单跑。
+  新增 24 个回归测试。
 - #27 跨市场配对解析改为只读 Gamma 主查：Gamma SDK `Market` 对象（嵌套
   `state.end_date`、`outcomes.yes/no.token_id`、`trading` 费率）与旧格式 dict
   （`outcomes` + `clobTokenIds`）都能解析 YES/NO token 并构造配对，旧格式保持

--- a/ops/launchd/com.open-trader.prediction-arbitrage-health.plist.template
+++ b/ops/launchd/com.open-trader.prediction-arbitrage-health.plist.template
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.open-trader.prediction-arbitrage-health</string>
+  <key>WorkingDirectory</key>
+  <string>OPEN_TRADER_REPO</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PYTHONPATH</key>
+    <string>OPEN_TRADER_REPO/src</string>
+  </dict>
+  <key>ProgramArguments</key>
+  <array>
+    <string>OPEN_TRADER_PYTHON</string>
+    <string>-m</string>
+    <string>open_trader</string>
+    <string>prediction-arb</string>
+    <string>health-check</string>
+    <string>--url</string>
+    <string>OPEN_TRADER_HEALTH_URL</string>
+    <string>--data-dir</string>
+    <string>OPEN_TRADER_DATA_DIR</string>
+    <string>--config</string>
+    <string>OPEN_TRADER_DAILY_CONFIG</string>
+    <string>--repo</string>
+    <string>OPEN_TRADER_REPO</string>
+    <string>--interval</string>
+    <string>OPEN_TRADER_HEALTH_INTERVAL</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>ProcessType</key>
+  <string>Interactive</string>
+  <key>ThrottleInterval</key>
+  <integer>5</integer>
+  <key>StandardOutPath</key>
+  <string>OPEN_TRADER_REPO/logs/prediction_arbitrage_health/launchd.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>OPEN_TRADER_REPO/logs/prediction_arbitrage_health/launchd.err.log</string>
+</dict>
+</plist>

--- a/scripts/install_prediction_arbitrage_health_launchd.sh
+++ b/scripts/install_prediction_arbitrage_health_launchd.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DRY_RUN=0
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RUNTIME_ROOT=""
+PYTHON_BIN="${OPEN_TRADER_PYTHON:-$REPO_ROOT/.venv/bin/python}"
+LAUNCH_AGENTS_DIR="${HOME}/Library/LaunchAgents"
+LAUNCHCTL_BIN="${LAUNCHCTL_BIN:-/bin/launchctl}"
+HEALTH_URL="${OPEN_TRADER_HEALTH_URL:-http://127.0.0.1:8766}"
+HEALTH_INTERVAL="${OPEN_TRADER_HEALTH_INTERVAL:-7200}"
+WAIT_SECONDS="${PREDICTION_HEALTH_LAUNCHD_WAIT_SECONDS:-30}"
+LABEL="com.open-trader.prediction-arbitrage-health"
+
+usage() {
+  echo "usage: $0 [--dry-run] [--repo-root PATH] [--runtime-root PATH] [--python PATH] [--launch-agents-dir PATH] [--url URL] [--interval SECONDS] [--wait-seconds N]" >&2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run) DRY_RUN=1; shift ;;
+    --repo-root) [[ $# -ge 2 ]] || { usage; exit 2; }; REPO_ROOT="$2"; shift 2 ;;
+    --runtime-root) [[ $# -ge 2 ]] || { usage; exit 2; }; RUNTIME_ROOT="$2"; shift 2 ;;
+    --python) [[ $# -ge 2 ]] || { usage; exit 2; }; PYTHON_BIN="$2"; shift 2 ;;
+    --launch-agents-dir) [[ $# -ge 2 ]] || { usage; exit 2; }; LAUNCH_AGENTS_DIR="$2"; shift 2 ;;
+    --url) [[ $# -ge 2 ]] || { usage; exit 2; }; HEALTH_URL="$2"; shift 2 ;;
+    --interval) [[ $# -ge 2 ]] || { usage; exit 2; }; HEALTH_INTERVAL="$2"; shift 2 ;;
+    --wait-seconds) [[ $# -ge 2 ]] || { usage; exit 2; }; WAIT_SECONDS="$2"; shift 2 ;;
+    *) usage; exit 2 ;;
+  esac
+done
+
+[[ "$HEALTH_INTERVAL" =~ ^[1-9][0-9]*$ ]] || { usage; exit 2; }
+[[ "$WAIT_SECONDS" =~ ^[1-9][0-9]*$ ]] || { usage; exit 2; }
+[[ -n "$HEALTH_URL" ]] || { usage; exit 2; }
+REPO_ROOT="$(cd "$REPO_ROOT" && pwd)"
+RUNTIME_ROOT="${RUNTIME_ROOT:-$REPO_ROOT}"
+RUNTIME_ROOT="$(cd "$RUNTIME_ROOT" 2>/dev/null && pwd || printf '%s' "$RUNTIME_ROOT")"
+TEMPLATE="$REPO_ROOT/ops/launchd/$LABEL.plist.template"
+PLIST_PATH="$LAUNCH_AGENTS_DIR/$LABEL.plist"
+DATA_DIR="$RUNTIME_ROOT/data"
+DAILY_CONFIG="$RUNTIME_ROOT/config/daily_premarket.env"
+OUT_LOG="$REPO_ROOT/logs/prediction_arbitrage_health/launchd.out.log"
+ERR_LOG="$REPO_ROOT/logs/prediction_arbitrage_health/launchd.err.log"
+
+[[ -f "$TEMPLATE" ]] || { echo "missing launchd template: $TEMPLATE" >&2; exit 1; }
+
+sed_escape() {
+  printf '%s' "$1" | sed 's/[\\&|]/\\&/g'
+}
+
+render_plist() {
+  sed \
+    -e "s|OPEN_TRADER_PYTHON|$(sed_escape "$PYTHON_BIN")|g" \
+    -e "s|OPEN_TRADER_DATA_DIR|$(sed_escape "$DATA_DIR")|g" \
+    -e "s|OPEN_TRADER_DAILY_CONFIG|$(sed_escape "$DAILY_CONFIG")|g" \
+    -e "s|OPEN_TRADER_REPO|$(sed_escape "$REPO_ROOT")|g" \
+    -e "s|OPEN_TRADER_HEALTH_URL|$(sed_escape "$HEALTH_URL")|g" \
+    -e "s|OPEN_TRADER_HEALTH_INTERVAL|$(sed_escape "$HEALTH_INTERVAL")|g" \
+    "$TEMPLATE"
+}
+
+lint_plist() {
+  local temp
+  temp="$(mktemp "${TMPDIR:-/tmp}/open-trader-health.XXXXXX.plist")"
+  printf '%s\n' "$1" > "$temp"
+  plutil -lint "$temp" >/dev/null
+  rm -f "$temp"
+}
+
+wait_agent_absent() {
+  local attempt output status
+  for attempt in 1 2 3 4 5; do
+    if output="$("$LAUNCHCTL_BIN" print "gui/$UID/$LABEL" 2>&1)"; then
+      status=0
+    else
+      status=$?
+    fi
+    if [[ "$status" -ne 0 && "$output" == *"Could not find service"* ]]; then
+      return 0
+    fi
+    if [[ "$status" -ne 0 ]]; then
+      echo "failed to inspect launchd label: $LABEL" >&2
+      printf '%s\n' "$output" >&2
+      return 1
+    fi
+    [[ "$attempt" -lt 5 ]] && sleep 1
+  done
+  echo "launchd job is still loaded: $LABEL" >&2
+  return 1
+}
+
+bootout_if_loaded() {
+  local output status
+  if output="$("$LAUNCHCTL_BIN" bootout "gui/$UID/$LABEL" 2>&1)"; then
+    return 0
+  else
+    status=$?
+  fi
+  if [[ "$output" == *"Could not find service"* || "$output" == *"No such process"* ]]; then
+    return 0
+  fi
+  printf '%s\n' "$output" >&2
+  return "$status"
+}
+
+wait_ready() {
+  local attempt output pid alive=0
+  for ((attempt = 1; attempt <= WAIT_SECONDS; attempt++)); do
+    output="$("$LAUNCHCTL_BIN" print "gui/$UID/$LABEL" 2>&1 || true)"
+    pid="$(printf '%s\n' "$output" | awk '$1 == "pid" && $2 == "=" && $3 ~ /^[0-9]+$/ { print $3; exit }')"
+    if [[ -n "$pid" ]]; then
+      alive=1
+      if [[ -s "$OUT_LOG" ]]; then
+        return 0
+      fi
+    fi
+    sleep 1
+  done
+  if [[ "$alive" -eq 1 ]]; then
+    echo "Prediction health service installed; startup log not confirmed within ${WAIT_SECONDS}s, job left running" >&2
+    return 0
+  fi
+  bootout_if_loaded || true
+  wait_agent_absent || return 1
+  echo "Prediction health service did not start" >&2
+  return 1
+}
+
+rendered="$(render_plist)"
+lint_plist "$rendered"
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  printf '%s\n' "$rendered"
+  exit 0
+fi
+
+mkdir -p "$LAUNCH_AGENTS_DIR" "$REPO_ROOT/logs/prediction_arbitrage_health" "$DATA_DIR"
+printf '%s\n' "$rendered" > "$PLIST_PATH"
+bootout_if_loaded
+wait_agent_absent
+: > "$OUT_LOG"
+: > "$ERR_LOG"
+"$LAUNCHCTL_BIN" bootstrap "gui/$UID" "$PLIST_PATH"
+wait_ready
+echo "installed launchd agent: $LABEL"

--- a/scripts/uninstall_prediction_arbitrage_health_launchd.sh
+++ b/scripts/uninstall_prediction_arbitrage_health_launchd.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LABEL="com.open-trader.prediction-arbitrage-health"
+LAUNCH_AGENTS_DIR="${LAUNCH_AGENTS_DIR:-$HOME/Library/LaunchAgents}"
+PLIST_PATH="$LAUNCH_AGENTS_DIR/$LABEL.plist"
+
+if /bin/launchctl bootout "gui/$UID/$LABEL" 2>/dev/null; then
+  echo "booted out: $LABEL"
+fi
+if [[ -f "$PLIST_PATH" ]]; then
+  rm -f "$PLIST_PATH"
+  echo "removed: $PLIST_PATH"
+else
+  echo "no plist at $PLIST_PATH"
+fi

--- a/src/open_trader/cli.py
+++ b/src/open_trader/cli.py
@@ -1120,6 +1120,22 @@ def build_parser() -> argparse.ArgumentParser:
     prediction_status.add_argument("--url", default="http://127.0.0.1:8766")
     prediction_status.add_argument("--timeout", type=positive_float, default=5.0)
 
+    health_parser = prediction_commands.add_parser(
+        "health-check", help="Run or serve the prediction-arbitrage health check"
+    )
+    health_parser.add_argument("--url", default="http://127.0.0.1:8766")
+    health_parser.add_argument("--data-dir", type=Path, default=Path("data"))
+    health_parser.add_argument(
+        "--config", type=Path, default=Path("config/daily_premarket.env")
+    )
+    health_parser.add_argument("--repo", type=Path, default=Path.cwd())
+    health_parser.add_argument(
+        "--interval", type=positive_float, default=7200.0
+    )
+    health_parser.add_argument("--once", action="store_true")
+    health_parser.add_argument("--no-notify", action="store_true")
+    health_parser.add_argument("--json", action="store_true")
+
     return parser
 
 
@@ -1377,6 +1393,29 @@ def main(argv: list[str] | None = None) -> int:
             print(f"masked_wallet: {payload.get('masked_wallet') or readiness.get('masked_address') or 'unknown'}")
             print(f"result: {'PASS' if status not in {'unavailable', 'error'} else 'BLOCKED'}")
             return 0 if status not in {"unavailable", "error"} else 2
+
+        if args.prediction_command == "health-check":
+            from .prediction_arbitrage_health import main as health_main
+
+            health_argv = [
+                "--url",
+                args.url,
+                "--data-dir",
+                str(args.data_dir),
+                "--config",
+                str(args.config),
+                "--repo",
+                str(args.repo),
+                "--interval",
+                str(args.interval),
+            ]
+            if args.once:
+                health_argv.append("--once")
+            if args.no_notify:
+                health_argv.append("--no-notify")
+            if args.json:
+                health_argv.append("--json")
+            return health_main(health_argv)
 
     if args.command == "trend-allocation":
         try:

--- a/src/open_trader/prediction_arbitrage_health.py
+++ b/src/open_trader/prediction_arbitrage_health.py
@@ -1,0 +1,425 @@
+"""Independent prediction-arbitrage health check service."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import time
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+from .daily_premarket import build_notifier, load_env_config
+from .notifications import NullNotifier
+
+
+HEARTBEAT_MAX_SECONDS = 60.0
+UNIVERSE_MAX_SECONDS = 300.0
+DEFAULT_INTERVAL_SECONDS = 7200.0
+_STATE_PATH = "api/prediction-arbitrage/state"
+_HEALTHZ_PATH = "healthz"
+
+
+@dataclass(frozen=True, slots=True)
+class Check:
+    name: str
+    status: str
+    value: str = ""
+    reason: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class HealthReport:
+    status: str
+    checks: tuple[Check, ...]
+    summary: dict[str, object]
+
+
+def _mapping(value: object) -> dict[str, object]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _seconds(value: object) -> float | None:
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _age(timestamp: object) -> float | None:
+    if not isinstance(timestamp, str) or not timestamp:
+        return None
+    try:
+        parsed = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return max((datetime.now(UTC) - parsed.astimezone(UTC)).total_seconds(), 0.0)
+
+
+def _fetch_state(url: str, timeout: float) -> Mapping[str, object]:
+    request = Request(f"{url.rstrip('/')}/{_STATE_PATH}", headers={"User-Agent": "OpenTrader/1.0"})
+    with urlopen(request, timeout=timeout) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+    if not isinstance(payload, Mapping):
+        raise ValueError("state payload must be an object")
+    return payload
+
+
+def _fetch_healthz(url: str, timeout: float) -> bool:
+    request = Request(f"{url.rstrip('/')}/{_HEALTHZ_PATH}", headers={"User-Agent": "OpenTrader/1.0"})
+    with urlopen(request, timeout=timeout) as response:
+        return response.status == 200
+
+
+def _llm_stats(data_dir: Path) -> tuple[int, int]:
+    path = data_dir / "prediction_arbitrage" / "prediction_arbitrage.sqlite3"
+    cutoff = datetime.now(UTC).isoformat(timespec="seconds")
+    with sqlite3.connect(f"file:{path}?mode=ro", uri=True) as connection:
+        row = connection.execute(
+            """
+            SELECT count(*), coalesce(sum(CASE WHEN status = 'success' THEN 1 ELSE 0 END), 0)
+            FROM llm_usage
+            WHERE kind = 'call' AND created_at >= ?
+            """,
+            (cutoff,),
+        ).fetchone()
+    return int(row[0]), int(row[1])
+
+
+def _process_info(repo_root: Path) -> dict[str, object] | None:
+    try:
+        output = subprocess.run(
+            ["ps", "-axo", "pid=,command="],
+            check=False,
+            capture_output=True,
+            text=True,
+        ).stdout
+    except OSError:
+        return None
+    pid = None
+    for line in output.splitlines():
+        candidate, _, command = line.strip().partition(" ")
+        if (
+            candidate.isdigit()
+            and "open_trader" in command
+            and " dashboard " in command
+            and "--port 8767" in command
+        ):
+            pid = candidate
+            break
+    if pid is None:
+        return None
+    cwd = None
+    try:
+        cwd_output = subprocess.run(
+            ["lsof", "-a", "-p", pid, "-d", "cwd", "-Fn"],
+            check=False,
+            capture_output=True,
+            text=True,
+        ).stdout
+    except OSError:
+        cwd_output = ""
+    for line in cwd_output.splitlines():
+        if line.startswith("n"):
+            cwd = line[1:]
+            break
+    sha = None
+    if cwd:
+        sha = (
+            subprocess.run(
+                ["git", "-C", cwd, "rev-parse", "HEAD"],
+                check=False,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            or None
+        )
+    expected_sha = subprocess.run(
+        ["git", "-C", str(repo_root), "rev-parse", "HEAD"],
+        check=False,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    return {"pid": pid, "sha": sha, "expected_sha": expected_sha}
+
+
+def run_health_check(
+    *,
+    url: str,
+    data_dir: Path,
+    repo_root: Path,
+    fetch_state: Callable[[str, float], Mapping[str, object]] = _fetch_state,
+    fetch_healthz: Callable[[str, float], bool] = _fetch_healthz,
+    llm_stats: Callable[[Path], tuple[int, int]] = _llm_stats,
+    process_info: Callable[[Path], dict[str, object] | None] = _process_info,
+    timeout: float = 10.0,
+    notify_configured: bool = True,
+) -> HealthReport:
+    """Run every component check and aggregate to PASS/WARN/FAIL."""
+
+    checks: list[Check] = []
+
+    def add(name: str, status: str, value: str = "", reason: str = "") -> None:
+        checks.append(Check(name=name, status=status, value=value, reason=reason))
+
+    try:
+        payload = fetch_state(url, timeout)
+    except Exception as exc:
+        payload = {}
+        add("endpoint", "FAIL", value=url, reason=f"{type(exc).__name__}: {exc}")
+    state_status = str(payload.get("status") or "unavailable")
+    if state_status in {"unavailable", "error"}:
+        add("state_status", "FAIL", value=state_status)
+    else:
+        add("state_status", "PASS", value=state_status)
+    if payload.get("stale") is True:
+        add("websocket", "FAIL", reason="stale websocket state")
+    else:
+        add("websocket", "PASS")
+    try:
+        healthz_ok = bool(fetch_healthz(url, timeout))
+    except Exception:
+        healthz_ok = False
+    add("gateway", "PASS" if healthz_ok else "FAIL", value=url, reason="" if healthz_ok else "healthz unavailable")
+
+    health = _mapping(payload.get("health"))
+    heartbeat = _seconds(health.get("heartbeat_age_seconds"))
+    if heartbeat is None:
+        heartbeat = _age(payload.get("heartbeat_at") or payload.get("heartbeat"))
+    if heartbeat is None:
+        add("heartbeat", "FAIL", reason="heartbeat timestamp missing")
+    elif heartbeat > HEARTBEAT_MAX_SECONDS:
+        add("heartbeat", "FAIL", value=f"{heartbeat:.1f}s", reason=f"older than {HEARTBEAT_MAX_SECONDS:.0f}s")
+    else:
+        add("heartbeat", "PASS", value=f"{heartbeat:.1f}s")
+
+    universe = _seconds(health.get("universe_age_seconds"))
+    if universe is None:
+        universe = _age(payload.get("universe_refreshed_at"))
+    if universe is None:
+        add("universe", "FAIL", reason="universe refresh timestamp missing")
+    elif universe > UNIVERSE_MAX_SECONDS:
+        add("universe", "FAIL", value=f"{universe:.1f}s", reason=f"older than {UNIVERSE_MAX_SECONDS:.0f}s")
+    else:
+        add("universe", "PASS", value=f"{universe:.1f}s")
+
+    breaker = _mapping(payload.get("breaker"))
+    if breaker.get("open") is True:
+        add("breaker", "FAIL", reason="execution breaker open")
+    else:
+        add("breaker", "PASS")
+
+    cross_venue = _mapping(payload.get("cross_venue"))
+    cross_status = str(cross_venue.get("status") or "unavailable")
+    funnel = _mapping(cross_venue.get("funnel"))
+    cross_value = (
+        f"matched={funnel.get('matched_pairs')} "
+        f"monitored={funnel.get('monitored_pairs')} "
+        f"approved={funnel.get('codex_approved_pairs')}"
+    )
+    if cross_status in {"unavailable", "error"}:
+        add("cross_venue", "FAIL", value=cross_status, reason="cross-venue discovery unavailable")
+    elif cross_status == "degraded":
+        add("cross_venue", "WARN", value=cross_status)
+    else:
+        add("cross_venue", "PASS", value=cross_status)
+
+    if health.get("universe_retry_exhausted") is True:
+        add("universe_retry", "FAIL", reason="universe refresh retries exhausted")
+    else:
+        add("universe_retry", "PASS")
+
+    relation = _mapping(payload.get("relation_discovery"))
+    relation_status = str(relation.get("status") or "")
+    catalog_status = str(_mapping(relation.get("catalog")).get("status") or "")
+    if relation_status in {"degraded", "unavailable"} or catalog_status in {"degraded", "unavailable"}:
+        add("relation_catalog", "WARN", value=f"discovery={relation_status or '-'} catalog={catalog_status or '-'}")
+    else:
+        add("relation_catalog", "PASS", value=f"discovery={relation_status or '-'} catalog={catalog_status or '-'}")
+
+    readiness = _mapping(payload.get("readiness"))
+    if readiness.get("ready") is True:
+        add("readiness", "PASS")
+    else:
+        reason = str(readiness.get("reason") or readiness.get("status") or "unavailable")
+        add("readiness", "FAIL", value=reason, reason="execution readiness blocked")
+
+    try:
+        llm_total, llm_success = llm_stats(data_dir)
+    except Exception as exc:
+        add("llm", "FAIL", reason=f"{type(exc).__name__}: {exc}")
+        llm_total, llm_success = 0, 0
+    else:
+        if llm_total == 0:
+            add("llm", "PASS", value="0/0", reason="no validation calls in window")
+        elif llm_success == 0:
+            add("llm", "FAIL", value=f"{llm_success}/{llm_total}", reason="no successful LLM validation in window")
+        else:
+            add("llm", "PASS", value=f"{llm_success}/{llm_total}")
+
+    try:
+        process = process_info(repo_root)
+    except Exception:
+        process = None
+    if process is None:
+        add("process", "FAIL", reason="dashboard process not found")
+        pid, sha = "none", "unknown"
+    else:
+        pid = str(process.get("pid") or "none")
+        sha = str(process.get("sha") or "unknown")
+        expected_sha = str(process.get("expected_sha") or "")
+        if sha != expected_sha:
+            add("process", "WARN", value=f"pid={pid} sha={sha}", reason="running SHA differs from repo HEAD")
+        else:
+            add("process", "PASS", value=f"pid={pid} sha={sha}")
+
+    if not notify_configured:
+        add("notify", "WARN", reason="Feishu not configured")
+
+    status = "PASS"
+    for check in checks:
+        if check.status == "FAIL":
+            status = "FAIL"
+            break
+        if check.status == "WARN":
+            status = "WARN"
+    return HealthReport(
+        status=status,
+        checks=tuple(checks),
+        summary={
+            "heartbeat_age": heartbeat,
+            "universe_age": universe,
+            "llm_total": llm_total,
+            "llm_success": llm_success,
+            "cross_venue": cross_status,
+            "pid": pid,
+            "sha": sha,
+        },
+    )
+
+
+def report_to_dict(report: HealthReport) -> dict[str, object]:
+    return {
+        "status": report.status,
+        "summary": report.summary,
+        "checks": [
+            {"name": check.name, "status": check.status, "value": check.value, "reason": check.reason}
+            for check in report.checks
+        ],
+    }
+
+
+def format_report(report: HealthReport) -> str:
+    summary = report.summary
+    line = (
+        f"{report.status} · heartbeat {summary.get('heartbeat_age') or '?'}s"
+        f" · universe {summary.get('universe_age') or '?'}s"
+        f" · LLM {summary.get('llm_success')}/{summary.get('llm_total')}"
+        f" · cross_venue {summary.get('cross_venue')}"
+        f" · PID {summary.get('pid')} · SHA {summary.get('sha')}"
+    )
+    if report.status == "PASS":
+        return line
+    lines = [line]
+    for check in report.checks:
+        if check.status == "PASS":
+            continue
+        detail = f" {check.value}" if check.value else ""
+        reason = f" ({check.reason})" if check.reason else ""
+        lines.append(f"- {check.status} {check.name}:{detail}{reason}")
+    return "\n".join(lines)
+
+
+def send_report(notifier: object, report: HealthReport) -> bool:
+    try:
+        notifier.notify(f"[预测套利健康检查] {report.status}", format_report(report))
+        return True
+    except Exception:
+        return False
+
+
+def _log(message: str) -> None:
+    print(f"{datetime.now(UTC).isoformat(timespec='seconds')} pid={os.getpid()} {message}", flush=True)
+
+
+def run_service(
+    notifier: object,
+    *,
+    url: str,
+    data_dir: Path,
+    repo_root: Path,
+    interval_seconds: float,
+    once: bool = False,
+    notify: bool = True,
+) -> int:
+    notify_configured = notify and not isinstance(notifier, NullNotifier)
+    if not once:
+        first = datetime.now(UTC).timestamp() + interval_seconds
+        _log(
+            f"health service started interval={interval_seconds:.0f}s "
+            f"first_check_at={datetime.fromtimestamp(first, UTC).isoformat(timespec='seconds')}"
+        )
+        time.sleep(interval_seconds)
+    while True:
+        report = run_health_check(
+            url=url,
+            data_dir=data_dir,
+            repo_root=repo_root,
+            notify_configured=notify_configured,
+        )
+        _log(format_report(report).replace("\n", " | "))
+        if notify_configured and not send_report(notifier, report):
+            _log(f"feishu delivery failed status={report.status}")
+        if once:
+            return 0 if report.status == "PASS" else (1 if report.status == "WARN" else 2)
+        time.sleep(interval_seconds)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="open-trader prediction-arb health-check")
+    parser.add_argument("--url", default="http://127.0.0.1:8766")
+    parser.add_argument("--data-dir", type=Path, default=Path("data"))
+    parser.add_argument("--config", type=Path, default=Path("config/daily_premarket.env"))
+    parser.add_argument("--repo", type=Path, default=Path.cwd())
+    parser.add_argument("--interval", type=float, default=DEFAULT_INTERVAL_SECONDS)
+    parser.add_argument("--once", action="store_true")
+    parser.add_argument("--no-notify", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+    try:
+        config = load_env_config(args.config)
+        notifier = NullNotifier() if args.no_notify else build_notifier(config)
+    except (FileNotFoundError, ValueError, RuntimeError) as exc:
+        print(f"health: BLOCKED\nresult: BLOCKED\nerror: {exc}", file=sys.stderr)
+        return 2
+    if args.once:
+        report = run_health_check(
+            url=args.url,
+            data_dir=args.data_dir,
+            repo_root=args.repo,
+            notify_configured=not args.no_notify and not isinstance(notifier, NullNotifier),
+        )
+        if args.json:
+            print(json.dumps(report_to_dict(report), ensure_ascii=False))
+        else:
+            print(format_report(report))
+        if not args.no_notify and not isinstance(notifier, NullNotifier):
+            if not send_report(notifier, report):
+                _log(f"feishu delivery failed status={report.status}")
+        return 0 if report.status == "PASS" else (1 if report.status == "WARN" else 2)
+    return run_service(
+        notifier,
+        url=args.url,
+        data_dir=args.data_dir,
+        repo_root=args.repo,
+        interval_seconds=args.interval,
+        notify=not args.no_notify,
+    )

--- a/tests/test_prediction_arbitrage_health.py
+++ b/tests/test_prediction_arbitrage_health.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from open_trader.prediction_arbitrage_health import (
+    format_report,
+    report_to_dict,
+    run_health_check,
+    send_report,
+)
+
+
+def base_state(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "status": "healthy",
+        "stale": False,
+        "health": {
+            "status": "healthy",
+            "heartbeat_age_seconds": 0.5,
+            "universe_age_seconds": 5.0,
+            "universe_retry_exhausted": False,
+        },
+        "breaker": {"open": False},
+        "cross_venue": {
+            "status": "ready",
+            "funnel": {
+                "matched_pairs": 13,
+                "monitored_pairs": 13,
+                "codex_approved_pairs": 5,
+            },
+        },
+        "relation_discovery": {
+            "status": "healthy",
+            "catalog": {"status": "healthy"},
+        },
+        "readiness": {"ready": True},
+    }
+    payload.update(overrides)
+    return payload
+
+
+def run_check(
+    *,
+    payload: dict[str, object] | None = None,
+    healthz: bool = True,
+    llm: tuple[int, int] = (10, 10),
+    process: dict[str, object] | None = {
+        "pid": "42",
+        "sha": "abc",
+        "expected_sha": "abc",
+    },
+    notify_configured: bool = True,
+):
+    return run_health_check(
+        url="http://127.0.0.1:8766",
+        data_dir=Path("data"),
+        repo_root=Path("."),
+        fetch_state=lambda *args: payload if payload is not None else base_state(),
+        fetch_healthz=lambda *args: healthz,
+        llm_stats=lambda *args: llm,
+        process_info=lambda *args: process,
+        notify_configured=notify_configured,
+    )
+
+
+def test_healthy_passes() -> None:
+    report = run_check()
+    assert report.status == "PASS"
+    assert report.summary["pid"] == "42"
+    assert report.summary["llm_success"] == 10
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        ({"stale": True}, "FAIL"),
+        ({"breaker": {"open": True}}, "FAIL"),
+        ({"status": "unavailable"}, "FAIL"),
+        ({"status": "error"}, "FAIL"),
+        ({"cross_venue": {"status": "unavailable", "funnel": {}}}, "FAIL"),
+        ({"cross_venue": {"status": "degraded", "funnel": {}}}, "WARN"),
+        (
+            {"health": {"heartbeat_age_seconds": 61.0, "universe_age_seconds": 5.0}},
+            "FAIL",
+        ),
+        (
+            {"health": {"heartbeat_age_seconds": 0.5, "universe_age_seconds": 301.0}},
+            "FAIL",
+        ),
+        (
+            {"health": {"heartbeat_age_seconds": 0.5, "universe_age_seconds": 5.0, "universe_retry_exhausted": True}},
+            "FAIL",
+        ),
+        (
+            {
+                "relation_discovery": {
+                    "status": "degraded",
+                    "catalog": {"status": "degraded"},
+                }
+            },
+            "WARN",
+        ),
+        ({"readiness": {"ready": False, "reason": "wallet_unavailable"}}, "FAIL"),
+    ],
+)
+def test_state_check_severity(payload: dict[str, object], expected: str) -> None:
+    report = run_check(payload=base_state(**payload))
+    assert report.status == expected
+
+
+def test_endpoint_exception_fails() -> None:
+    report = run_health_check(
+        url="http://127.0.0.1:8766",
+        data_dir=Path("data"),
+        repo_root=Path("."),
+        fetch_state=lambda *args: (_ for _ in ()).throw(ConnectionError("down")),
+        fetch_healthz=lambda *args: True,
+        llm_stats=lambda *args: (10, 10),
+        process_info=lambda *args: {"pid": "42", "sha": "abc", "expected_sha": "abc"},
+    )
+    assert report.status == "FAIL"
+    assert any(check.name == "endpoint" and check.status == "FAIL" for check in report.checks)
+
+
+def test_gateway_down_fails() -> None:
+    assert run_check(healthz=False).status == "FAIL"
+
+
+def test_llm_no_success_fails() -> None:
+    assert run_check(llm=(10, 0)).status == "FAIL"
+
+
+def test_llm_no_calls_passes() -> None:
+    assert run_check(llm=(0, 0)).status == "PASS"
+
+
+def test_process_missing_fails() -> None:
+    assert run_check(process=None).status == "FAIL"
+
+
+def test_process_sha_mismatch_warns() -> None:
+    report = run_check(process={"pid": "42", "sha": "old", "expected_sha": "new"})
+    assert report.status == "WARN"
+
+
+def test_notify_unconfigured_warns() -> None:
+    assert run_check(notify_configured=False).status == "WARN"
+
+
+def test_format_pass_is_single_line() -> None:
+    text = format_report(run_check())
+    assert text.startswith("PASS · heartbeat 0.5s")
+    assert "\n" not in text
+
+
+def test_format_fail_lists_checks() -> None:
+    report = run_check(llm=(10, 0))
+    text = format_report(report)
+    assert text.startswith("FAIL · heartbeat")
+    assert "- FAIL llm: 0/10" in text
+
+
+def test_report_to_dict_is_jsonable() -> None:
+    import json
+
+    data = report_to_dict(run_check())
+    assert data["status"] == "PASS"
+    assert json.dumps(data)
+
+
+def test_send_report_calls_notifier() -> None:
+    calls: list[tuple[str, str]] = []
+
+    class FakeNotifier:
+        def notify(self, title: str, message: str) -> None:
+            calls.append((title, message))
+
+    assert send_report(FakeNotifier(), run_check()) is True
+    assert calls[0][0] == "[预测套利健康检查] PASS"
+    assert calls[0][1].startswith("PASS ·")
+
+
+def test_send_report_returns_false_on_failure() -> None:
+    class BrokenNotifier:
+        def notify(self, title: str, message: str) -> None:
+            raise RuntimeError("boom")
+
+    assert send_report(BrokenNotifier(), run_check()) is False


### PR DESCRIPTION
## 背景

Issue #29：套利模块故障曾连续数天无感知。新增独立健康检查后端服务，每 2 小时检查整套套利组件并发送飞书 PASS/WARN/FAIL。

## 变更

- 新增 `prediction-arb health-check` 命令（`--once` 手动单跑 / 默认常驻服务）
- 独立 launchd 服务 `com.open-trader.prediction-arbitrage-health`（RunAtLoad + KeepAlive，只装生产环境，避免多 worktree 重复发送）
- 检查项：8766 状态端点 + healthz、heartbeat≤60s、universe≤300s、breaker、cross-venue、relation catalog、universe_retry_exhausted、readiness（执行被挡即 FAIL）、LLM 近 2h 成功率、dashboard PID/运行 SHA
- 飞书：每次运行都发（PASS 一行摘要，WARN/FAIL 逐项带值带原因）；未配置飞书显示 WARN；发送失败记日志下轮重试
- 安装/卸载脚本 + launchd 模板 + CHANGELOG

## 验证

- 新增 24 个回归测试全部通过（PASS/WARN/FAIL 判定、格式、通知路径）
- live 自检（`--once --no-notify --json`）：端点/healthz/heartbeat/breaker/cross_venue/readiness/进程 SHA 全部通过；universe 309s>300s 按约定判 FAIL；LLM 近 2h 无调用判 PASS（0/0）
- 未发送真实飞书；首条真实消息由安装后 2 小时的首周期发出

## 部署（merge 后）

1. 在 main checkout 运行 `scripts/install_prediction_arbitrage_health_launchd.sh`
2. 确认 `launchctl list` 有 `com.open-trader.prediction-arbitrage-health` 且日志出现 `health service started`
3. 2 小时后确认飞书收到第一条健康检查消息
