### PR TITLE
fix: read dashboard loaded git SHA from startup log (#29)

### DIFF
--- a/src/open_trader/prediction_arbitrage_health.py
+++ b/src/open_trader/prediction_arbitrage_health.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sqlite3
 import subprocess
 import sys
@@ -117,31 +118,7 @@ def _process_info(repo_root: Path) -> dict[str, object] | None:
             break
     if pid is None:
         return None
-    cwd = None
-    try:
-        cwd_output = subprocess.run(
-            ["lsof", "-a", "-p", pid, "-d", "cwd", "-Fn"],
-            check=False,
-            capture_output=True,
-            text=True,
-        ).stdout
-    except OSError:
-        cwd_output = ""
-    for line in cwd_output.splitlines():
-        if line.startswith("n"):
-            cwd = line[1:]
-            break
-    sha = None
-    if cwd:
-        sha = (
-            subprocess.run(
-                ["git", "-C", cwd, "rev-parse", "HEAD"],
-                check=False,
-                capture_output=True,
-                text=True,
-            ).stdout.strip()
-            or None
-        )
+    sha = _dashboard_git_sha(repo_root)
     expected_sha = subprocess.run(
         ["git", "-C", str(repo_root), "rev-parse", "HEAD"],
         check=False,
@@ -149,6 +126,18 @@ def _process_info(repo_root: Path) -> dict[str, object] | None:
         text=True,
     ).stdout.strip()
     return {"pid": pid, "sha": sha, "expected_sha": expected_sha}
+
+
+def _dashboard_git_sha(repo_root: Path) -> str | None:
+    """Read the git SHA the dashboard process actually loaded from its startup log."""
+
+    log = Path(repo_root) / "logs" / "legacy_dashboard" / "launchd.out.log"
+    try:
+        text = log.read_text(errors="replace")
+    except OSError:
+        return None
+    match = re.search(r'"git_sha":\s*"([0-9a-f]{7,40})"', text)
+    return match.group(1) if match else None
 
 
 def run_health_check(

--- a/tests/test_prediction_arbitrage_health.py
+++ b/tests/test_prediction_arbitrage_health.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from open_trader.prediction_arbitrage_health import (
+    _dashboard_git_sha,
     format_report,
     report_to_dict,
     run_health_check,
@@ -188,3 +189,17 @@ def test_send_report_returns_false_on_failure() -> None:
             raise RuntimeError("boom")
 
     assert send_report(BrokenNotifier(), run_check()) is False
+
+
+def test_dashboard_git_sha_reads_startup_log(tmp_path: Path) -> None:
+    log = tmp_path / "logs" / "legacy_dashboard" / "launchd.out.log"
+    log.parent.mkdir(parents=True)
+    log.write_text(
+        'dashboard_runtime: {"pid": 44548, "git_sha": '
+        '"64809e3f45d8c8f1a53cf80d98c497027dc5d590", "source_state": "clean"}'
+    )
+    assert _dashboard_git_sha(tmp_path) == "64809e3f45d8c8f1a53cf80d98c497027dc5d590"
+
+
+def test_dashboard_git_sha_returns_none_without_log(tmp_path: Path) -> None:
+    assert _dashboard_git_sha(tmp_path) is None


### PR DESCRIPTION
健康检查原来用进程 cwd 的 git HEAD 当运行 SHA，main pull 后会把仍在跑旧代码的进程误报为最新。改为解析 legacy_dashboard 启动日志里的 dashboard_runtime git_sha（进程真正加载的版本），日志缺失时 WARN。新增 2 个回归，共 26 个测试通过。