### PR TITLE
fix: use latest dashboard startup git_sha in health check (#29)

### DIFF
--- a/src/open_trader/prediction_arbitrage_health.py
+++ b/src/open_trader/prediction_arbitrage_health.py
@@ -136,8 +136,8 @@ def _dashboard_git_sha(repo_root: Path) -> str | None:
         text = log.read_text(errors="replace")
     except OSError:
         return None
-    match = re.search(r'"git_sha":\s*"([0-9a-f]{7,40})"', text)
-    return match.group(1) if match else None
+    matches = re.findall(r'"git_sha":\s*"([0-9a-f]{7,40})"', text)
+    return matches[-1] if matches else None
 
 
 def run_health_check(

--- a/tests/test_prediction_arbitrage_health.py
+++ b/tests/test_prediction_arbitrage_health.py
@@ -196,9 +196,11 @@ def test_dashboard_git_sha_reads_startup_log(tmp_path: Path) -> None:
     log.parent.mkdir(parents=True)
     log.write_text(
         'dashboard_runtime: {"pid": 44548, "git_sha": '
-        '"64809e3f45d8c8f1a53cf80d98c497027dc5d590", "source_state": "clean"}'
+        '"64809e3f45d8c8f1a53cf80d98c497027dc5d590", "source_state": "clean"}\n'
+        'dashboard_runtime: {"pid": 94923, "git_sha": '
+        '"ca308877fec207773786c16e98317fcec77aba70", "source_state": "clean"}'
     )
-    assert _dashboard_git_sha(tmp_path) == "64809e3f45d8c8f1a53cf80d98c497027dc5d590"
+    assert _dashboard_git_sha(tmp_path) == "ca308877fec207773786c16e98317fcec77aba70"
 
 
 def test_dashboard_git_sha_returns_none_without_log(tmp_path: Path) -> None:


### PR DESCRIPTION
启动日志累积多条 dashboard_runtime，原实现取第一条（旧 SHA）。改为取最后一条（当前进程实际加载版本）。新增回归：多条日志行时返回最新 SHA。26 个测试通过。